### PR TITLE
Add Gmail OAuth2 support

### DIFF
--- a/backend/src/config.cpp
+++ b/backend/src/config.cpp
@@ -1,8 +1,15 @@
 #include "config.h"
+#include <cstdlib>
 
 // Gmail OAuth2 Configuration
-const std::string GmailConfig::CLIENT_ID = "YOUR_GMAIL_CLIENT_ID";
-const std::string GmailConfig::CLIENT_SECRET = "YOUR_GMAIL_CLIENT_SECRET";
+const std::string GmailConfig::CLIENT_ID = []{
+    const char* val = std::getenv("GMAIL_CLIENT_ID");
+    return val ? std::string(val) : std::string("YOUR_GMAIL_CLIENT_ID");
+}();
+const std::string GmailConfig::CLIENT_SECRET = []{
+    const char* val = std::getenv("GMAIL_CLIENT_SECRET");
+    return val ? std::string(val) : std::string("YOUR_GMAIL_CLIENT_SECRET");
+}();
 const std::string GmailConfig::REDIRECT_URI = "http://localhost:8080/oauth/gmail/callback";
 const std::string GmailConfig::AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
 const std::string GmailConfig::TOKEN_URL = "https://oauth2.googleapis.com/token";


### PR DESCRIPTION
## Summary
- add new Gmail OAuth2 endpoints in the backend server
- read Gmail OAuth2 credentials from environment variables

## Testing
- `./build.sh` *(fails: could not find `nlohmann_json` during CMake configuration)*

------
https://chatgpt.com/codex/tasks/task_b_6855b0a8ab44832f8ce2f6169d3ce179